### PR TITLE
Support immutable multi-corpus replay schedules

### DIFF
--- a/subprojects/06_dataset_scheduling_experiments/tests/test_scheduled_sequence_reader.py
+++ b/subprojects/06_dataset_scheduling_experiments/tests/test_scheduled_sequence_reader.py
@@ -115,14 +115,110 @@ class ScheduledSequenceReaderTests(unittest.TestCase):
             self.assertEqual(payload.active_tokens, 0)
             self.assertEqual(int(payload.tokens.sum()), 0)
 
-    def test_rejects_schedule_and_packed_active_count_drift(self) -> None:
+    def test_accepts_terminal_active_cap_without_rewriting_payload(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             schedule = self._fixture(Path(tmp), scheduled_active=4095)
             reader = MODULE.ScheduledSequenceReader(schedule, "D0_mixed")
-            with self.assertRaisesRegex(ValueError, "scheduled/packed active-token drift"):
+            payload = reader[0]
+            self.assertEqual(payload.active_tokens, 4095)
+            np.testing.assert_array_equal(payload.tokens, np.arange(4097, dtype=np.int64))
+
+    def test_rejects_zero_active_non_filler(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            schedule = self._fixture(Path(tmp), scheduled_active=0)
+            reader = MODULE.ScheduledSequenceReader(schedule, "D0_mixed")
+            with self.assertRaisesRegex(ValueError, "invalid scheduled active-token cap"):
                 reader[0]
+
+    def test_rejects_active_cap_larger_than_packed_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            schedule = self._fixture(Path(tmp), scheduled_active=4097)
+            reader = MODULE.ScheduledSequenceReader(schedule, "D0_mixed")
+            with self.assertRaisesRegex(ValueError, "invalid scheduled active-token cap"):
+                reader[0]
+
+    def test_stationary_schedule_reads_multiple_packed_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            legacy = self._fixture(root)
+            legacy_value = json.loads(legacy.read_text())
+            packed_one = root / "packed.json"
+            binary_two = root / "bucket_two.bin"
+            active_two = root / "bucket_two.active.u16"
+            (np.arange(4097, dtype=np.int32) + 10000).tofile(binary_two)
+            np.asarray([4000], dtype=np.uint16).tofile(active_two)
+            bucket_two = root / "bucket_two.manifest.json"
+            bucket_two.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "apertus_fixed_sequence_bucket_v1",
+                        "status": "completed",
+                        "pool_code": 3,
+                        "bucket": 4,
+                        "pad_token_id": 10,
+                        "sequence_count": 1,
+                        "stored_tokens_per_sequence": 4097,
+                        "sequence_length": 4096,
+                        "outputs": {
+                            "bin": file_receipt(binary_two),
+                            "active_counts": file_receipt(active_two),
+                        },
+                    }
+                )
+                + "\n"
+            )
+            packed_two = root / "packed_two.json"
+            packed_two.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "apertus_packed_sequence_corpus_v1",
+                        "status": "completed",
+                        "packing_task_manifests": [
+                            {
+                                "manifest_path": str(bucket_two),
+                                "manifest_sha256": sha(bucket_two),
+                                "pool": "old_greek_replay",
+                                "bucket": 4,
+                            }
+                        ],
+                    }
+                )
+                + "\n"
+            )
+            ids = root / "stationary.ids"
+            active = root / "stationary.active"
+            sequence_one = (2 << 62) | (3 << 55)
+            sequence_two = (3 << 62) | (4 << 55)
+            np.asarray([sequence_one, sequence_two], dtype=np.uint64).tofile(ids)
+            np.asarray([4095, 3999], dtype=np.uint16).tofile(active)
+            stationary = root / "stationary.json"
+            stationary.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "apertus_cpt_stationary_replay_schedule_v1",
+                        "status": "completed",
+                        "schedule_id": "stationary",
+                        "sequence_count": 2,
+                        "sequence_ids": file_receipt(ids),
+                        "active_tokens_per_sequence": file_receipt(active),
+                        "packed_corpus_receipts": [
+                            {"path": str(packed_one), "sha256": sha(packed_one)},
+                            {"path": str(packed_two), "sha256": sha(packed_two)},
+                        ],
+                        "checks": {
+                            "every_selected_sequence_scheduled_once": True,
+                            "payload_not_rewritten": True,
+                        },
+                    }
+                )
+                + "\n"
+            )
+            self.assertIn("packed_corpus_receipt", legacy_value)
+            reader = MODULE.ScheduledSequenceReader(stationary, "stationary")
+            self.assertEqual(reader[0].active_tokens, 4095)
+            self.assertEqual(reader[1].active_tokens, 3999)
+            self.assertEqual(int(reader[1].tokens[0]), 10000)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/subprojects/06_dataset_scheduling_experiments/training/scheduled_sequence_reader.py
+++ b/subprojects/06_dataset_scheduling_experiments/training/scheduled_sequence_reader.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read immutable packed rows through a D0-D4 sequence-ID schedule.
+"""Read immutable packed rows through a receipt-bound sequence-ID schedule.
 
 The schedule changes only the order in which stable sequence payloads are
 visited.  It never reconstructs or repacks text, which keeps document masks,
@@ -115,30 +115,55 @@ class ScheduledSequenceReader:
     def __init__(self, schedule_manifest: Path, arm_id: str):
         schedule_manifest = schedule_manifest.resolve()
         schedule = read_json(schedule_manifest)
-        if (
-            schedule.get("schema_version")
-            not in {
-                "apertus_mini_five_data_order_schedules_v1",
-                "apertus_data_order_schedules_v1",
-            }
-            or schedule.get("status") != "completed"
-            or schedule.get("common_contract", {}).get("same_exact_sequence_multiset")
-            is not True
-            or schedule.get("common_contract", {}).get(
-                "same_replay_sequence_ids_at_same_global_positions"
-            )
-            is not True
-        ):
-            raise ValueError("schedule manifest is not a completed five-arm receipt")
-        arms = {row["arm_id"]: row for row in schedule["arms"]}
-        if arm_id not in arms:
-            raise KeyError(f"unknown schedule arm: {arm_id}")
-        arm = arms[arm_id]
-        ids_path = checked_file(arm["sequence_ids"])
-        active_path = checked_file(arm["active_tokens"])
+        schema = schedule.get("schema_version")
+        legacy_schemas = {
+            "apertus_mini_five_data_order_schedules_v1",
+            "apertus_data_order_schedules_v1",
+        }
+        if schema in legacy_schemas:
+            if (
+                schedule.get("status") != "completed"
+                or schedule.get("common_contract", {}).get("same_exact_sequence_multiset")
+                is not True
+                or schedule.get("common_contract", {}).get(
+                    "same_replay_sequence_ids_at_same_global_positions"
+                )
+                is not True
+            ):
+                raise ValueError("schedule manifest is not a completed five-arm receipt")
+            arms = {row["arm_id"]: row for row in schedule["arms"]}
+            if arm_id not in arms:
+                raise KeyError(f"unknown schedule arm: {arm_id}")
+            arm = arms[arm_id]
+            ids_receipt = arm["sequence_ids"]
+            active_receipt = arm["active_tokens"]
+            length = int(arm["training_slots"])
+            packed_receipts = [schedule["packed_corpus_receipt"]]
+        elif schema == "apertus_cpt_stationary_replay_schedule_v1":
+            if (
+                schedule.get("status") != "completed"
+                or schedule.get("checks", {}).get("every_selected_sequence_scheduled_once")
+                is not True
+                or schedule.get("checks", {}).get("payload_not_rewritten") is not True
+            ):
+                raise ValueError("stationary schedule is not a completed immutable receipt")
+            schedule_id = schedule.get("schedule_id")
+            if arm_id != schedule_id:
+                raise KeyError(f"unknown schedule arm: {arm_id}")
+            ids_receipt = schedule["sequence_ids"]
+            active_receipt = schedule["active_tokens_per_sequence"]
+            length = int(schedule["sequence_count"])
+            packed_receipts = schedule.get("packed_corpus_receipts")
+            if not isinstance(packed_receipts, list) or not packed_receipts:
+                raise ValueError("stationary schedule omits packed corpus receipts")
+        else:
+            raise ValueError(f"unsupported schedule schema: {schema}")
+
+        ids_path = checked_file(ids_receipt)
+        active_path = checked_file(active_receipt)
         self.arm_id = arm_id
         self.schedule_manifest = schedule_manifest
-        self.length = int(arm["training_slots"])
+        self.length = length
         if ids_path.stat().st_size != self.length * 8:
             raise ValueError("sequence-ID schedule byte geometry drift")
         if active_path.stat().st_size != self.length * 2:
@@ -150,29 +175,33 @@ class ScheduledSequenceReader:
             active_path, mode="r", dtype=np.uint16, shape=(self.length,)
         )
 
-        packed_receipt_info = schedule["packed_corpus_receipt"]
-        packed_path = Path(packed_receipt_info["path"]).resolve()
-        if sha256_file(packed_path) != packed_receipt_info["sha256"]:
-            raise ValueError("packed corpus receipt drift")
-        packed = read_json(packed_path)
-        if (
-            packed.get("schema_version")
-            not in {
-                "apertus_mini_packed_sequence_corpus_v1",
-                "apertus_packed_sequence_corpus_v1",
-            }
-            or packed.get("status") != "completed"
-        ):
-            raise ValueError("packed corpus is not completed")
         self.buckets: dict[tuple[int, int], _PackedBucket] = {}
         pad_ids = set()
-        for row in packed["packing_task_manifests"]:
-            bucket = _PackedBucket(Path(row["manifest_path"]).resolve())
-            key = (bucket.pool_code, bucket.bucket)
-            if key in self.buckets:
-                raise ValueError(f"duplicate packed bucket: {key}")
-            self.buckets[key] = bucket
-            pad_ids.add(bucket.pad_token_id)
+        for packed_receipt_info in packed_receipts:
+            packed_path = Path(packed_receipt_info["path"]).resolve()
+            if sha256_file(packed_path) != packed_receipt_info["sha256"]:
+                raise ValueError("packed corpus receipt drift")
+            packed = read_json(packed_path)
+            if (
+                packed.get("schema_version")
+                not in {
+                    "apertus_mini_packed_sequence_corpus_v1",
+                    "apertus_packed_sequence_corpus_v1",
+                }
+                or packed.get("status") != "completed"
+            ):
+                raise ValueError("packed corpus is not completed")
+            for row in packed["packing_task_manifests"]:
+                manifest_path = Path(row["manifest_path"]).resolve()
+                expected_manifest_sha = row.get("manifest_sha256")
+                if expected_manifest_sha and sha256_file(manifest_path) != expected_manifest_sha:
+                    raise ValueError(f"packed bucket manifest drift: {manifest_path}")
+                bucket = _PackedBucket(manifest_path)
+                key = (bucket.pool_code, bucket.bucket)
+                if key in self.buckets:
+                    raise ValueError(f"duplicate packed bucket: {key}")
+                self.buckets[key] = bucket
+                pad_ids.add(bucket.pad_token_id)
         if len(pad_ids) != 1:
             raise ValueError(f"packed pad-token drift: {sorted(pad_ids)}")
         self.pad_token_id = next(iter(pad_ids))
@@ -209,14 +238,14 @@ class ScheduledSequenceReader:
         if source is None:
             raise KeyError(f"schedule points to missing packed bucket: {(pool, bucket)}")
         tokens, packed_active = source.get(row)
-        if packed_active != scheduled_active:
+        if scheduled_active <= 0 or scheduled_active > packed_active:
             raise ValueError(
-                f"scheduled/packed active-token drift for {sequence_id}: "
-                f"{scheduled_active} != {packed_active}"
+                f"invalid scheduled active-token cap for {sequence_id}: "
+                f"{scheduled_active} not in [1, {packed_active}]"
             )
         return SequencePayload(
             sequence_id=sequence_id,
             tokens=tokens,
-            active_tokens=packed_active,
+            active_tokens=scheduled_active,
             filler=False,
         )

--- a/subprojects/06_dataset_scheduling_experiments/training/smoke_scheduled_packed_dataset.py
+++ b/subprojects/06_dataset_scheduling_experiments/training/smoke_scheduled_packed_dataset.py
@@ -70,7 +70,8 @@ def fixture(root: Path) -> Path:
         ids = root / f"{arm}.ids"
         counts = root / f"{arm}.active"
         np.asarray([sequence_id, np.uint64(2**64 - 1)], dtype=np.uint64).tofile(ids)
-        np.asarray([4000, 0], dtype=np.uint16).tofile(counts)
+        # Cap the final packed target by one without rewriting the payload.
+        np.asarray([3999, 0], dtype=np.uint16).tofile(counts)
         arms.append(
             {
                 "arm_id": arm,
@@ -122,7 +123,7 @@ def main() -> int:
             sample = dataset[0]
             filler = dataset[1]
             assert sample["tokens"].shape == sample["labels"].shape == (4096,)
-            assert int(sample["loss_mask"][4000:].sum()) == 0
+            assert int(sample["loss_mask"][3999:].sum()) == 0
             assert int(filler["loss_mask"].sum()) == 0
             assert sample["position_ids"][101].item() == 0
             outputs.append(sample)
@@ -134,4 +135,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
Adds the reader contract needed by the reusable replay reservoir.

- accepts the stationary replay schedule schema
- binds separate main and replay packed-corpus receipts
- preserves the legacy five-arm path
- permits exact loss-active terminal caps without rewriting tokens
- rejects zero/oversized caps and duplicate packed bucket identities
- adds byte-parity, multi-receipt, and capped-tail smoke coverage

This PR is not used by the live early-cooldown campaign; promotion requires the Clariden uenv smoke and startup-budget gate.