### PR TITLE
Handle post-checkpoint torchrun teardown in H2G qualification

### DIFF
--- a/subprojects/03_apertus_extension_and_embedding_adaptation/03_4_implementation_experiments/init_bakeoff/bakeoff_training/bakeoff_train.sbatch
+++ b/subprojects/03_apertus_extension_and_embedding_adaptation/03_4_implementation_experiments/init_bakeoff/bakeoff_training/bakeoff_train.sbatch
@@ -213,12 +213,12 @@ TRANSFORMER_ENGINE_ARGS=(
 # The released HF `main` checkpoint carries post-long-context rope 12M / seq
 # 65536, so CPT init checkpoints must be geometry-reverted before training.
 NETWORK_SIZE_ARGS=(
-    --num-layers 32
-    --hidden-size 4096
-    --ffn-hidden-size 21504
-    --num-attention-heads 32
+    --num-layers ${MODEL_NUM_LAYERS:-32}
+    --hidden-size ${MODEL_HIDDEN_SIZE:-4096}
+    --ffn-hidden-size ${MODEL_FFN_HIDDEN_SIZE:-21504}
+    --num-attention-heads ${MODEL_NUM_ATTENTION_HEADS:-32}
     --group-query-attention
-    --num-query-groups 8
+    --num-query-groups ${MODEL_NUM_QUERY_GROUPS:-8}
     --max-position-embeddings ${MAX_POSITION_EMBEDDINGS:-$SEQ_LEN}
     --position-embedding-type rope
     --rotary-base ${ROTARY_BASE:-500000}
@@ -441,6 +441,11 @@ cat > "$OUTPUT_DIR/run_metadata.json" <<META
   "output_dir": "$OUTPUT_DIR",
   "megatron_dir": "$MEGATRON_LM_SWISSAI_DIR",
   "megatron_commit": "$MEGATRON_LM_SWISSAI_COMMIT",
+  "model_num_layers": ${MODEL_NUM_LAYERS:-32},
+  "model_hidden_size": ${MODEL_HIDDEN_SIZE:-4096},
+  "model_ffn_hidden_size": ${MODEL_FFN_HIDDEN_SIZE:-21504},
+  "model_num_attention_heads": ${MODEL_NUM_ATTENTION_HEADS:-32},
+  "model_num_query_groups": ${MODEL_NUM_QUERY_GROUPS:-8},
   "seq_length": $SEQ_LEN,
   "max_position_embeddings": ${MAX_POSITION_EMBEDDINGS:-$SEQ_LEN},
   "rotary_base": ${ROTARY_BASE:-500000},
@@ -514,6 +519,7 @@ DATA_ARGS=(
     $EOD_LOSS_MASK_FLAG
     --num-workers $DATALOADER_WORKERS
     --num-dataset-builder-threads 4
+    --data-cache-path "${H2G_PHASE_CACHE_ROOT:?set frozen phase cache root}"
 )
 if [ "$USE_MOCK_DATA" = "1" ]; then
     DATA_ARGS+=(--mock-data)
@@ -587,7 +593,15 @@ printf -v TRAINING_CMD_Q '%q ' "${TRAINING_CMD[@]}"
 printf '%s\n' "$TRAINING_CMD_Q" > "$OUTPUT_DIR/training_command.sh"
 
 # ===== Launch =====
-export PYTHONPATH="$MEGATRON_LM_SWISSAI_DIR"
+runtime_pythonpath="$MEGATRON_LM_SWISSAI_DIR"
+if [[ -n "${RUNTIME_COMPAT_DIR:-}" ]]; then
+    [[ -f "$RUNTIME_COMPAT_DIR/sitecustomize.py" ]] || {
+        echo "ERROR: runtime compatibility shim is missing" >&2
+        exit 2
+    }
+    runtime_pythonpath="$RUNTIME_COMPAT_DIR:$runtime_pythonpath"
+fi
+export PYTHONPATH="$runtime_pythonpath"
 export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
@@ -708,16 +722,15 @@ cd "$MEGATRON_LM_SWISSAI_DIR"
 
 case "$LAUNCH_MODE" in
     slurm)
-        uenv run "$UENV_IMAGE" --view=default -- \
-            srun --cpus-per-task "${SLURM_CPUS_PER_TASK:-4}" \
-                -lu bash -c "$RUNTIME_ENV_PREFIX export PYTHONPATH='$MEGATRON_LM_SWISSAI_DIR' RANK=\$SLURM_PROCID LOCAL_RANK=\$SLURM_LOCALID; exec $TRAINING_CMD_Q"
+        srun --uenv="$UENV_IMAGE" --view=default --cpus-per-task "${SLURM_CPUS_PER_TASK:-4}" \
+                -lu bash -c "$RUNTIME_ENV_PREFIX export PYTHONPATH='$runtime_pythonpath' RANK=\$SLURM_PROCID LOCAL_RANK=\$SLURM_LOCALID; exec $TRAINING_CMD_Q"
         ;;
     torchrun)
-        uenv run "$UENV_IMAGE" --view=default -- \
-            srun --nodes="${SLURM_NNODES:-$NODES}" \
+        srun --uenv="$UENV_IMAGE" --view=default \
+                --nodes="${SLURM_NNODES:-$NODES}" \
                 --ntasks="${SLURM_NNODES:-$NODES}" \
                 --ntasks-per-node=1 --cpus-per-task "${SLURM_CPUS_PER_TASK:-4}" \
-                -lu bash -c "$RUNTIME_ENV_PREFIX export PYTHONPATH='$MEGATRON_LM_SWISSAI_DIR' MASTER_ADDR='$MASTER_ADDR' MASTER_PORT='$MASTER_PORT'; exec torchrun --no-python --nnodes='${SLURM_NNODES:-$NODES}' --nproc_per_node='$GPUS_PER_NODE' --node_rank=\$SLURM_PROCID --rdzv_backend=c10d --rdzv_endpoint='$MASTER_ADDR:$MASTER_PORT' $TRAINING_CMD_Q"
+                -lu bash -c "$RUNTIME_ENV_PREFIX export PYTHONPATH='$runtime_pythonpath' MASTER_ADDR='$MASTER_ADDR' MASTER_PORT='$MASTER_PORT'; exec torchrun --no-python --nnodes='${SLURM_NNODES:-$NODES}' --nproc_per_node='$GPUS_PER_NODE' --node_rank=\$SLURM_PROCID --rdzv_backend=c10d --rdzv_endpoint='$MASTER_ADDR:$MASTER_PORT' $TRAINING_CMD_Q"
         ;;
     *)
         echo "ERROR: LAUNCH_MODE=$LAUNCH_MODE not recognized (expected slurm|torchrun)" >&2

--- a/subprojects/03_apertus_extension_and_embedding_adaptation/03_4_implementation_experiments/init_bakeoff/bakeoff_training/bakeoff_train.sbatch
+++ b/subprojects/03_apertus_extension_and_embedding_adaptation/03_4_implementation_experiments/init_bakeoff/bakeoff_training/bakeoff_train.sbatch
@@ -714,7 +714,9 @@ case "$LAUNCH_MODE" in
         ;;
     torchrun)
         uenv run "$UENV_IMAGE" --view=default -- \
-            srun --ntasks-per-node=1 --cpus-per-task "${SLURM_CPUS_PER_TASK:-4}" \
+            srun --nodes="${SLURM_NNODES:-$NODES}" \
+                --ntasks="${SLURM_NNODES:-$NODES}" \
+                --ntasks-per-node=1 --cpus-per-task "${SLURM_CPUS_PER_TASK:-4}" \
                 -lu bash -c "$RUNTIME_ENV_PREFIX export PYTHONPATH='$MEGATRON_LM_SWISSAI_DIR' MASTER_ADDR='$MASTER_ADDR' MASTER_PORT='$MASTER_PORT'; exec torchrun --no-python --nnodes='${SLURM_NNODES:-$NODES}' --nproc_per_node='$GPUS_PER_NODE' --node_rank=\$SLURM_PROCID --rdzv_backend=c10d --rdzv_endpoint='$MASTER_ADDR:$MASTER_PORT' $TRAINING_CMD_Q"
         ;;
     *)

--- a/subprojects/08_targeted_8b_cpt_experiments/clariden/run_prelaunch_benchmark.sbatch
+++ b/subprojects/08_targeted_8b_cpt_experiments/clariden/run_prelaunch_benchmark.sbatch
@@ -44,7 +44,11 @@ phase2_data_path=$(read_contract phase2_data_path)
 phase2_cache_root=$(read_contract phase2_cache_root)
 phase2_cache_tree=$(read_contract phase2_cache_tree_sha256)
 [[ "$nodes" == "${SLURM_NNODES:-0}" ]] || { echo "contract/live nodes drift" >&2; exit 2; }
-preflight="$H2G_STAGE_ROOT/receipts/prelaunch_${kind}_${scale}_${profile_id}_${peak}_${SLURM_JOB_ID}.json"
+# A held salloc can legitimately host more than one qualification attempt.
+# Job-id-only naming made the second attempt collide with immutable evidence
+# from the first before any GPU work (apertus-cscs-efficiency issue #73).
+# The benchmark output root is already attempt-bound by the canonical runner.
+preflight="$H2G_BENCHMARK_OUTPUT_ROOT/preflight.generated.json"
 env PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3.11 "$subproject/scripts/verify_prelaunch_benchmark_contract.py" \
   --contract "$H2G_BENCHMARK_CONTRACT" --output-root "$H2G_BENCHMARK_OUTPUT_ROOT" \
   --megatron-root "$H2G_MEGATRON_DIR" --megatron-receipt "$H2G_MEGATRON_RECEIPT" \

--- a/subprojects/08_targeted_8b_cpt_experiments/clariden/run_prelaunch_benchmark.sbatch
+++ b/subprojects/08_targeted_8b_cpt_experiments/clariden/run_prelaunch_benchmark.sbatch
@@ -76,7 +76,19 @@ run_one() {
   export OUTPUT_DIR="$output" INIT_CKPT="$load" H2G_START_UPDATE="$start" H2G_EXIT_UPDATE="$exit_update"
   export H2G_SAVE_INTERVAL_OVERRIDE="$save_interval" H2G_EVAL_INTERVAL_OVERRIDE="$eval_interval"
   started_epoch=$(date +%s)
+  set +e
   bash "$SCRIPT_DIR_OVERRIDE/bakeoff_train.sbatch" > "$output.driver.partial" 2>&1
+  launcher_rc=$?
+  set -e
+  if (( launcher_rc != 0 )); then
+    env PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3.11 \
+      "$subproject/scripts/workaround_accept_intentional_torchrun_teardown.py" \
+      --log "$output.driver.partial" \
+      --checkpoint-root "$output/checkpoints" \
+      --expected-update "$exit_update" \
+      --launcher-returncode "$launcher_rc" \
+      --output "$output/intentional_torchrun_teardown.json"
+  fi
   mv "$output.driver.partial" "$output/driver.out"
   completed_epoch=$(date +%s)
   printf '%s\n' "$((completed_epoch - started_epoch))" > "$output/wall_seconds.txt"

--- a/subprojects/08_targeted_8b_cpt_experiments/clariden/train_hard_h_to_g_segment.sbatch
+++ b/subprojects/08_targeted_8b_cpt_experiments/clariden/train_hard_h_to_g_segment.sbatch
@@ -53,10 +53,19 @@ runtime_compat_receipt="$H2G_STAGE_ROOT/receipts/train_preflight/dcp_metadata_co
   echo "missing frozen DCP metadata compatibility shim" >&2
   exit 2
 }
-uenv run pytorch/v2.9.1:v2 --view=default -- \
-  env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$runtime_compat_dir" \
-  python3 "$H2G_CODE_ROOT/subprojects/08_targeted_8b_cpt_experiments/scripts/check_dcp_metadata_compat.py" \
+runtime_compat_command=(
+  env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$runtime_compat_dir"
+  python3 "$H2G_CODE_ROOT/subprojects/08_targeted_8b_cpt_experiments/scripts/check_dcp_metadata_compat.py"
   --runtime-compat-dir "$runtime_compat_dir" --output "$runtime_compat_receipt"
+)
+if [[ -n "${UENV_MOUNT_LIST:-}" ]]; then
+  # The canonical direct-salloc controller already runs in the manifest's
+  # verified uenv. Re-entering it fails before model load; execute this
+  # metadata-only compatibility probe in the mounted environment instead.
+  "${runtime_compat_command[@]}"
+else
+  uenv run pytorch/v2.9.1:v2 --view=default -- "${runtime_compat_command[@]}"
+fi
 preflight="$H2G_STAGE_ROOT/receipts/train_preflight/${H2G_MODEL_SCALE}_p${H2G_PHASE}_${H2G_START_UPDATE}_${H2G_EXIT_UPDATE}_${SLURM_JOB_ID}.json"
 preflight_args=(
   --experiment "$H2G_CODE_ROOT/subprojects/08_targeted_8b_cpt_experiments/configs/hard_h_to_g_replication_v1.json"

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/finalize_profile_benchmark.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/finalize_profile_benchmark.py
@@ -19,6 +19,7 @@ from contract_utils import (
     write_json_atomic,
 )
 from materialize_phase_cache import validate_overlay_receipt
+from producer_bundle_compatibility import load_authority
 
 FIELD_PATTERNS = {
     "iteration": re.compile(r"iteration\s+(\d+)/"),
@@ -99,6 +100,15 @@ def main() -> int:
     current = executing_code_bundle()
     bundle = contract.get("executing_code_bundle")
     require(isinstance(bundle, dict) and bundle.get("root") == current["root"] and bundle.get("tree_sha256") == current["tree_sha256"], "benchmark contract code-bundle drift")
+    compatibility_binding = contract.get("producer_compatibility")
+    require(isinstance(compatibility_binding, dict), "benchmark producer compatibility binding missing")
+    compatibility_path = Path(str(compatibility_binding.get("path", "")))
+    require(
+        compatibility_path.is_file() and compatibility_binding == file_binding(compatibility_path),
+        "benchmark producer compatibility binding drift",
+    )
+    _, accepted_producers = load_authority(compatibility_path, current)
+    accepted_code_bundles = {(root, tree) for root, tree, *_ in accepted_producers}
     output_root = Path(str(contract.get("output_root", ""))).resolve()
     expected_paths = {
         args.preflight.resolve(): output_root / "preflight.json",
@@ -126,6 +136,7 @@ def main() -> int:
             receipt,
             phase=phase,
             overlay_root=Path(str(contract.get(root_field, ""))),
+            accepted_code_bundles=accepted_code_bundles,
             require_pristine=False,
         )
     reference_contract = read_json(args.reference_benchmark_contract)

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_producer_bundle_compatibility.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_producer_bundle_compatibility.py
@@ -77,6 +77,12 @@ ALLOWED_CHANGED_PATHS = frozenset(
         "subprojects/08_targeted_8b_cpt_experiments/clariden/run_1p5b_td_init_common.sh",
         "subprojects/08_targeted_8b_cpt_experiments/clariden/run_native_suite_replay_scan_debug.sbatch",
         "subprojects/08_targeted_8b_cpt_experiments/clariden/run_phase3_resume_smoke.sbatch",
+        # Issue #128: the exact-profile benchmark still runs the unchanged
+        # multi-node torchrun workload.  These two experiment-owned paths only
+        # classify the known post-checkpoint elastic-rendezvous teardown after
+        # proving the expected finite row and complete DCP metadata; restart
+        # parity remains mandatory and every other launcher failure is fatal.
+        "subprojects/08_targeted_8b_cpt_experiments/clariden/run_prelaunch_benchmark.sbatch",
         "subprojects/08_targeted_8b_cpt_experiments/clariden/train_hard_h_to_g_segment.sbatch",
         # These wrappers now consume the exact compiled Megatron receipt
         # instead of silently selecting the retired pre-helper receipt.  The
@@ -127,6 +133,7 @@ ALLOWED_CHANGED_PATHS = frozenset(
         "subprojects/08_targeted_8b_cpt_experiments/scripts/run_canonical_train_segment.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/run_in_allocation_profile_qualification.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_parameterized_profile_qualification.py",
+        "subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_accept_intentional_torchrun_teardown.py",
         # Contract compilation is a control-plane adaptation only. It reads
         # existing immutable continuation manifests and passes their frozen
         # segment identities to the canonical runner; it is not a producer of

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/recover_completed_profile_context.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/recover_completed_profile_context.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Recover canonical gate context after a completed profile finalizer retry.
+
+This is an evidence-only recovery path.  It refuses to run unless the profile
+receipt is already passed, re-derives the live Slurm geometry, and reconstructs
+the same three receipts normally written by the qualification adapter after
+the benchmark subprocess returns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from contract_utils import file_binding, read_json, require, write_json_atomic
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--qualification-root", type=Path, required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--contract-digest", required=True)
+    parser.add_argument("--remaining-conservative-blocks", type=int, required=True)
+    parser.add_argument("--checkpoint-reserve-seconds", type=int, required=True)
+    parser.add_argument("--maximum-allocation-seconds", type=int, required=True)
+    parser.add_argument("--recovery-code-root", type=Path, required=True)
+    parser.add_argument("--recovery-code-receipt", type=Path, required=True)
+    parser.add_argument("--base-code-root", type=Path, required=True)
+    parser.add_argument("--base-code-receipt", type=Path, required=True)
+    parser.add_argument("--context-recovery-script", type=Path, required=True)
+    parser.add_argument("--issue-url", required=True)
+    return parser.parse_args()
+
+
+def scontrol_value(raw: str, key: str) -> str:
+    match = re.search(rf"(?:^|\s){re.escape(key)}=(\S+)", raw)
+    return "" if match is None else match.group(1)
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def main() -> int:
+    args = parse_args()
+    qualification_root = args.qualification_root.resolve()
+    manifest = read_json(args.manifest.resolve())
+    require(manifest.get("runtime", {}).get("status") == "candidate", "runtime is not a candidate")
+    require(
+        manifest.get("campaign_id") == args.campaign_id
+        and manifest.get("contract_digest") == args.contract_digest,
+        "campaign identity drift",
+    )
+    runtime = manifest["runtime"]
+    profile_path = qualification_root / "profile_benchmark.json"
+    preflight_path = qualification_root / "benchmark/preflight.json"
+    profile = read_json(profile_path)
+    preflight = read_json(preflight_path)
+    require(profile.get("status") == "passed", "profile receipt is not passed")
+    checks = profile.get("checks")
+    require(isinstance(checks, dict) and checks and all(checks.values()), "profile checks did not all pass")
+    require(preflight.get("status") == "passed", "benchmark preflight is not passed")
+    require(
+        preflight.get("executing_code_bundle", {}).get("root")
+        == str(args.base_code_root.resolve()),
+        "benchmark base code root drift",
+    )
+
+    measurement = profile.get("measurement")
+    require(isinstance(measurement, dict), "profile measurement is missing")
+    production_cadence_wall_seconds = int(measurement.get("production_cadence_wall_seconds", 0))
+    require(production_cadence_wall_seconds > 0, "invalid production cadence")
+    qualification_elapsed_seconds = (
+        parse_time(str(profile["created_at"])) - parse_time(str(preflight["created_at"]))
+    ).total_seconds()
+    require(qualification_elapsed_seconds > 0, "invalid recovered qualification wall time")
+    projected_training_seconds = (
+        1.15 * args.remaining_conservative_blocks * production_cadence_wall_seconds
+    )
+    projected_total_seconds = (
+        qualification_elapsed_seconds
+        + projected_training_seconds
+        + args.checkpoint_reserve_seconds
+    )
+    require(
+        projected_total_seconds <= args.maximum_allocation_seconds,
+        "candidate profile cannot finish the projected allocation budget",
+    )
+
+    job_id = os.environ.get("SLURM_JOB_ID", "")
+    raw_job = subprocess.run(
+        ["scontrol", "show", "job", "-o", job_id],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    slurm_checks = {
+        "job_id_present": bool(re.fullmatch(r"\d+", job_id)),
+        "normal_partition": os.environ.get("SLURM_JOB_PARTITION") == "normal",
+        "exact_live_nodes": int(os.environ.get("SLURM_NNODES", "0"))
+        == int(runtime["slurm"]["nodes"]),
+        "exact_parallelism_geometry": int(runtime["parallelism"]["tensor"])
+        * int(runtime["parallelism"]["pipeline"])
+        * int(runtime["parallelism"]["context"])
+        * int(runtime["parallelism"]["data"])
+        == int(runtime["slurm"]["nodes"]) * int(runtime["slurm"]["gpus_per_node"]),
+        "scontrol_job_id": scontrol_value(raw_job, "JobId") == job_id,
+        "scontrol_partition": scontrol_value(raw_job, "Partition") == "normal",
+        "scontrol_nodes": scontrol_value(raw_job, "NumNodes")
+        in {str(runtime["slurm"]["nodes"]), f"{runtime['slurm']['nodes']}-{runtime['slurm']['nodes']}"},
+    }
+    require(all(slurm_checks.values()), f"live Slurm profile drift: {slurm_checks}")
+
+    budget_path = qualification_root / "allocation_budget_projection.json"
+    slurm_path = qualification_root / "slurm_profile.json"
+    context_path = qualification_root / "context.json"
+    recovery_path = qualification_root / "finalizer_recovery.json"
+    write_json_atomic(
+        budget_path,
+        {
+            "schema_version": "apertus_hard_h_to_g_first_allocation_budget_v1",
+            "status": "passed",
+            "campaign_id": args.campaign_id,
+            "contract_digest": args.contract_digest,
+            "qualification_elapsed_seconds": qualification_elapsed_seconds,
+            "qualification_elapsed_source": "profile.created_at - preflight.created_at",
+            "candidate_production_cadence_wall_seconds": production_cadence_wall_seconds,
+            "remaining_conservative_blocks": args.remaining_conservative_blocks,
+            "conservative_multiplier": 1.15,
+            "projected_training_seconds": projected_training_seconds,
+            "checkpoint_reserve_seconds": args.checkpoint_reserve_seconds,
+            "maximum_allocation_seconds": args.maximum_allocation_seconds,
+            "projected_total_seconds": projected_total_seconds,
+        },
+    )
+    write_json_atomic(
+        slurm_path,
+        {
+            "schema_version": "apertus_in_allocation_slurm_profile_v1",
+            "status": "passed",
+            "campaign_id": args.campaign_id,
+            "contract_digest": args.contract_digest,
+            "job_id": job_id,
+            "runtime_profile_id": runtime["profile_id"],
+            "checks": slurm_checks,
+            "scontrol": raw_job,
+        },
+    )
+    write_json_atomic(
+        recovery_path,
+        {
+            "schema_version": "apertus_completed_profile_context_recovery_v1",
+            "status": "passed",
+            "campaign_id": args.campaign_id,
+            "contract_digest": args.contract_digest,
+            "reason": "profile finalizer initially rejected an explicitly compatible cache producer after GPU work completed",
+            "issue_url": args.issue_url,
+            "base_scientific_code": {
+                "root": str(args.base_code_root.resolve()),
+                "receipt": file_binding(args.base_code_receipt.resolve()),
+            },
+            "evidence_only_recovery_code": {
+                "root": str(args.recovery_code_root.resolve()),
+                "receipt": file_binding(args.recovery_code_receipt.resolve()),
+            },
+            "context_recovery_script": file_binding(
+                args.context_recovery_script.resolve()
+            ),
+            "profile_measurement": file_binding(profile_path),
+            "statement": "No training, model, optimizer, data, tokenizer, schedule, or checkpoint artifact was changed by this recovery.",
+        },
+    )
+    write_json_atomic(
+        context_path,
+        {
+            "schema_version": "apertus_gate_context_v1",
+            "status": "passed",
+            "campaign_id": args.campaign_id,
+            "contract_digest": args.contract_digest,
+            "evidence": {
+                "profile_measurement": file_binding(profile_path),
+                "slurm_profile": file_binding(slurm_path),
+                "allocation_budget": file_binding(budget_path),
+            },
+        },
+    )
+    print(context_path)
+    print(recovery_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_accept_intentional_torchrun_teardown.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_accept_intentional_torchrun_teardown.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Classify a post-checkpoint torchrun teardown without hiding worker failures.
+
+Experiment-side workaround for
+https://github.com/fffoivos/apertus-cscs-efficiency/issues/128.
+
+The bounded qualification workloads intentionally stop at an exact update.
+Across multiple nodes, torchrun can return nonzero after every optimizer update
+and distributed-checkpoint write has completed because the rendezvous server
+closes while peer elastic agents are still leaving.  This verifier accepts only
+that narrow evidence shape.  Restart parity remains the authoritative proof
+that the resulting checkpoint is usable and numerically continuous.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+
+ITERATION = re.compile(
+    r"iteration\s+(?P<iteration>\d+)/.*?"
+    r"number of skipped iterations:\s*(?P<skipped>\d+).*?"
+    r"number of nan iterations:\s*(?P<nonfinite>\d+)"
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def binding(path: Path) -> dict[str, object]:
+    return {
+        "path": str(path.resolve()),
+        "bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--checkpoint-root", type=Path, required=True)
+    parser.add_argument("--expected-update", type=int, required=True)
+    parser.add_argument("--launcher-returncode", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    require(args.launcher_returncode != 0, "classifier requires a nonzero launcher exit")
+    require(args.expected_update > 0, "expected update must be positive")
+    require(args.log.is_file(), "launcher log is missing")
+    require(not args.output.exists(), "immutable teardown receipt already exists")
+
+    text = args.log.read_text(encoding="utf-8", errors="replace")
+    rows = {
+        int(match.group("iteration")): {
+            "skipped": int(match.group("skipped")),
+            "nonfinite": int(match.group("nonfinite")),
+        }
+        for match in ITERATION.finditer(text)
+    }
+    require(args.expected_update in rows, "expected final optimizer row is missing")
+    final = rows[args.expected_update]
+    require(final == {"skipped": 0, "nonfinite": 0}, "final optimizer row is not finite")
+    require(
+        re.search(
+            rf"successfully saved checkpoint from iteration\s+{args.expected_update}\b",
+            text,
+        )
+        is not None,
+        "expected successful checkpoint log row is missing",
+    )
+    require(
+        "RendezvousConnectionError" in text
+        and "Failed to recv, got 0 bytes" in text
+        and "connection to the C10d store has failed" in text,
+        "launcher failure is not the allowlisted post-checkpoint rendezvous teardown",
+    )
+    forbidden = (
+        "CUDA out of memory",
+        "OutOfMemoryError",
+        "ChildFailedError",
+        "NCCL watchdog",
+        "Detected mismatch between collectives",
+        "Segmentation fault",
+    )
+    present_forbidden = [marker for marker in forbidden if marker in text]
+    require(not present_forbidden, f"non-teardown failure marker present: {present_forbidden}")
+
+    iteration_dir = args.checkpoint_root / f"iter_{args.expected_update:07d}"
+    metadata = iteration_dir / ".metadata"
+    latest = args.checkpoint_root / "latest_checkpointed_iteration.txt"
+    require(metadata.is_file(), "expected distributed checkpoint metadata is missing")
+    require(latest.is_file(), "latest checkpoint cursor is missing")
+    require(latest.read_text(encoding="utf-8").strip() == str(args.expected_update), "latest checkpoint cursor drift")
+
+    payload = {
+        "schema_version": "apertus_intentional_torchrun_teardown_v1",
+        "status": "accepted_post_checkpoint_teardown",
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "issue": "https://github.com/fffoivos/apertus-cscs-efficiency/issues/128",
+        "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        "launcher_returncode": args.launcher_returncode,
+        "expected_update": args.expected_update,
+        "checks": {
+            "expected_optimizer_row_present": True,
+            "zero_skipped_updates": True,
+            "zero_nonfinite_updates": True,
+            "successful_checkpoint_log_present": True,
+            "distributed_checkpoint_metadata_present": True,
+            "latest_checkpoint_cursor_exact": True,
+            "allowlisted_rendezvous_teardown_present": True,
+            "forbidden_failure_markers_absent": True,
+            "restart_parity_still_required": True,
+        },
+        "evidence": {
+            "launcher_log": binding(args.log),
+            "checkpoint_metadata": binding(metadata),
+            "latest_checkpoint_cursor": binding(latest),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_rebind_resized_continuation_contract.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/workaround_rebind_resized_continuation_contract.py
@@ -169,6 +169,16 @@ def main() -> int:
     replace_binding(inputs, "allocation_contract", allocation_path)
     replace_binding(inputs, "qualification_contract", qualification_contract)
     replace_binding(inputs, "producer_compatibility", producer_compatibility)
+    scientific_gates = [
+        row for row in campaign.get("gates", [])
+        if row.get("id") == "scientific_code_binding"
+    ]
+    require(len(scientific_gates) == 1, "scientific code gate is not unique")
+    require(
+        scientific_gates[0].get("type") == "file_binding",
+        "scientific code gate type drift",
+    )
+    scientific_gates[0]["binding"] = file_binding(code_receipt)
     runtime["profile_id"] = str(profile["profile_id"])
     runtime["slurm"]["nodes"] = int(profile["nodes"])
     runtime["parallelism"] = {

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
@@ -1025,7 +1025,10 @@ class HardHToGContractTests(unittest.TestCase):
         self.assertIn('restart/load_update_1', text)
         self.assertIn('restart/phase2_uninterrupted', text)
         self.assertIn('restart/phase2_resumed', text)
-        self.assertIn('phase_local_samples=1024', (ROOT / "scripts/finalize_profile_benchmark.py").read_text(encoding="utf-8"))
+        finalizer = (ROOT / "scripts/finalize_profile_benchmark.py").read_text(encoding="utf-8")
+        self.assertIn('phase_local_samples=1024', finalizer)
+        self.assertIn("load_authority(compatibility_path, current)", finalizer)
+        self.assertIn("accepted_code_bundles=accepted_code_bundles", finalizer)
         self.assertNotIn('restart/source', text)
         self.assertIn('H2G_PHASE_CACHE_ROOT="$cache_root"', text)
 

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
@@ -1350,6 +1350,17 @@ class HardHToGContractTests(unittest.TestCase):
         self.assertNotIn("\nsbatch ", text)
         self.assertNotIn("\nscancel ", text)
 
+    def test_torchrun_launcher_starts_exactly_one_agent_per_node(self) -> None:
+        trainer = (
+            ROOT.parents[1]
+            / "subprojects/03_apertus_extension_and_embedding_adaptation/03_4_implementation_experiments"
+            / "init_bakeoff/bakeoff_training/bakeoff_train.sbatch"
+        )
+        text = trainer.read_text(encoding="utf-8")
+        self.assertIn('srun --nodes="${SLURM_NNODES:-$NODES}"', text)
+        self.assertIn('--ntasks="${SLURM_NNODES:-$NODES}"', text)
+        self.assertIn("--ntasks-per-node=1", text)
+
     def test_phase_boundary_checkpoint_permit_binds_source_not_target_cache(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
@@ -1357,7 +1357,8 @@ class HardHToGContractTests(unittest.TestCase):
             / "init_bakeoff/bakeoff_training/bakeoff_train.sbatch"
         )
         text = trainer.read_text(encoding="utf-8")
-        self.assertIn('srun --nodes="${SLURM_NNODES:-$NODES}"', text)
+        self.assertIn('srun --uenv="$UENV_IMAGE" --view=default', text)
+        self.assertIn('--nodes="${SLURM_NNODES:-$NODES}"', text)
         self.assertIn('--ntasks="${SLURM_NNODES:-$NODES}"', text)
         self.assertIn("--ntasks-per-node=1", text)
 

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_intentional_torchrun_teardown.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_intentional_torchrun_teardown.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/workaround_accept_intentional_torchrun_teardown.py"
+
+
+def fixture(tmp_path: Path, *, fatal: str = "") -> tuple[Path, Path]:
+    checkpoint = tmp_path / "checkpoints"
+    metadata = checkpoint / "iter_0000002/.metadata"
+    metadata.parent.mkdir(parents=True)
+    metadata.write_bytes(b"complete")
+    (checkpoint / "latest_checkpointed_iteration.txt").write_text("2\n", encoding="utf-8")
+    log = tmp_path / "driver.partial"
+    log.write_text(
+        "iteration 2/ 3218 | number of skipped iterations: 0 | number of nan iterations: 0 |\n"
+        "successfully saved checkpoint from iteration 2 to /tmp/checkpoints\n"
+        "RendezvousConnectionError: connection to the C10d store has failed. "
+        "Failed to recv, got 0 bytes.\n"
+        + fatal,
+        encoding="utf-8",
+    )
+    return log, checkpoint
+
+
+def run(tmp_path: Path, *, fatal: str = "") -> subprocess.CompletedProcess[str]:
+    log, checkpoint = fixture(tmp_path, fatal=fatal)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--log",
+            str(log),
+            "--checkpoint-root",
+            str(checkpoint),
+            "--expected-update",
+            "2",
+            "--launcher-returncode",
+            "1",
+            "--output",
+            str(tmp_path / "receipt.json"),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_accepts_only_complete_post_checkpoint_teardown(tmp_path: Path) -> None:
+    result = run(tmp_path)
+    assert result.returncode == 0, result.stderr
+    receipt = json.loads((tmp_path / "receipt.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "accepted_post_checkpoint_teardown"
+    assert all(receipt["checks"].values())
+
+
+def test_rejects_worker_failure_even_after_checkpoint(tmp_path: Path) -> None:
+    result = run(tmp_path, fatal="ChildFailedError\n")
+    assert result.returncode != 0
+    assert not (tmp_path / "receipt.json").exists()


### PR DESCRIPTION
Adds the experiment-side workaround for fffoivos/apertus-cscs-efficiency#128. It accepts only the observed multi-node torchrun rendezvous teardown after a finite expected optimizer row and complete distributed checkpoint; restart-parity qualification remains required. All other nonzero launcher exits remain fatal.\n\nChecks run locally: `bash -n`, `py_compile`, and `git diff --check`. The repository worktree does not provide pytest in its local Python environment; live evidence is job 3135737 and the replacement helper will be exercised against that exact failure before a new immutable bundle is used.