### PR TITLE
Do not gate Phase 3 on GreekMMLU calibration

### DIFF
--- a/subprojects/08_targeted_8b_cpt_experiments/HARD_H_TO_G_8B_1P5B_REPLICATION_PLAN_20260814.md
+++ b/subprojects/08_targeted_8b_cpt_experiments/HARD_H_TO_G_8B_1P5B_REPLICATION_PLAN_20260814.md
@@ -1204,10 +1204,11 @@ not saturation.
 13. **Launch main segmented trajectories:** run the historical segmented
     harness for `R-HG-8B` and `R-HG-1p5B`, concurrently only when disjoint
     audited allocations are available.
-14. **Same-stack sentinel calibration:** score the complete clean panel and both
-    nested subsets in the early and late four-checkpoint windows; authorize
-    4,096, expand to 8,192 or activate full-panel fallback only after both
-    window tests resolve exactly as Section 8 specifies.
+14. **Start same-stack sentinel calibration in parallel:** score the complete
+    clean panel and both nested subsets from the saved early and late
+    four-checkpoint windows; authorize 4,096, expand to 8,192 or activate
+    full-panel fallback only after both window tests resolve exactly as Section
+    8 specifies. This evaluation-only decision does not gate optimizer entry.
 15. **Replication-endpoint freeze:** at update 3,218, verify complete
     model/optimizer/RNG/phase-local data-cursor receipts before any extension
     update becomes authoritative.
@@ -1215,15 +1216,17 @@ not saturation.
     separate unseen Phase-3 blend/cache, consume it from cursor zero at constant
     floor LR, and force exact saves at 3,456 and 3,694; prove both phase-local
     transitions before the corresponding segment is authorized.
-17. **Evaluation and finalization:** complete all source, GreekMMLU and native-
-    Greek receipts; enforce selection authorization; publish raw per-question
-    predictions; and generate separate A, B and C verdicts.
+17. **Evaluation and finalization:** complete sentinel calibration plus all
+    source, GreekMMLU and native-Greek receipts; enforce selection
+    authorization; publish raw per-question predictions; and generate separate
+    A, B and C verdicts. Sentinel calibration gates this stage.
 
 No launch gate may be stamped true by construction. Every gate requires the
 path and SHA-256 of its backing receipt and the immutable executable bundle.
 The gates are chronological: `pre_main`, `pre_extension`,
 `pre_second_extension`, and `pre_finalization`. Post-update artifacts are never
-required by an earlier gate.
+required by an earlier gate. Evaluation-only sentinel calibration is allowed
+to overlap Phase 3 and becomes mandatory only at `pre_finalization`.
 
 ## 11. CSCS resource policy
 

--- a/subprojects/08_targeted_8b_cpt_experiments/README.md
+++ b/subprojects/08_targeted_8b_cpt_experiments/README.md
@@ -96,7 +96,9 @@ Current executable entry points are:
 Every production segment, including the first, must pass the authorization
 gate appropriate to its stage inside `preflight_train_segment.py`. Phase 1/2
 requires `pre_main`; Phase 3 production requires `pre_extension` and then
-`pre_second_extension`. The one-update Phase-3 proof jobs consume the previous
+`pre_second_extension`. GreekMMLU sentinel calibration is evaluation-only: it
+runs concurrently from the saved checkpoints and gates `pre_finalization`, not
+Phase-3 optimizer entry. The one-update Phase-3 proof jobs consume the previous
 stage's gate so they can produce, rather than circularly require, the next
 gate. A direct `sbatch` therefore cannot bypass the staged artifact manifest or
 owner authorization.

--- a/subprojects/08_targeted_8b_cpt_experiments/README.md
+++ b/subprojects/08_targeted_8b_cpt_experiments/README.md
@@ -89,9 +89,16 @@ Current executable entry points are:
   authorization only after the other 25 roles pass, and produce the immutable
   launch-ready pre-main gate; every manifest accepts only explicitly audited
   producer bundles; and
-- Phase-3 cursor and constant-floor continuation are checked from checkpoint
-  metadata, frozen cache identities and deterministic scheduler/data-loader
-  simulation before submission. No one-update `normal` proof job is required.
+- Phase-3 cursor and constant-floor continuation are checked by the frozen
+  one-update resume path against checkpoint metadata and exact cache identity.
+  Run those checks inside the already-held scale-matched allocations; they do
+  not justify separate `normal` allocations.
+
+The cross-scale realized-ledger authority accepts only producer bundles named
+by the audited compatibility receipt. It treats a scale-specific cache as
+matched only when it is either the canonical cache byte-for-byte or a proven
+hardlink superset whose cache-build and overlay receipts bind every canonical
+training-index file unchanged; validation-only cache additions are ignored.
 
 Every production segment, including the first, must pass the authorization
 gate appropriate to its stage inside `preflight_train_segment.py`. Phase 1/2

--- a/subprojects/08_targeted_8b_cpt_experiments/clariden/freeze_cross_scale_realized_ledger_debug.sbatch
+++ b/subprojects/08_targeted_8b_cpt_experiments/clariden/freeze_cross_scale_realized_ledger_debug.sbatch
@@ -17,6 +17,7 @@ set -euo pipefail
 : "${H2G_STAGE_ROOT:?set immutable stage root}"
 : "${H2G_8B_UPDATE_3218_PERMIT:?set exact canonical 8B update-3218 permit}"
 : "${H2G_1P5B_UPDATE_3218_PERMIT:?set exact canonical 1.5B update-3218 permit}"
+: "${H2G_PRODUCER_COMPATIBILITY:?set audited producer-bundle compatibility authority}"
 [[ "${SLURM_JOB_PARTITION:-}" == debug && "${SLURM_NNODES:-0}" == 1 ]] || { echo "ledger authority requires one debug node" >&2; exit 2; }
 /usr/bin/python3.11 "$H2G_CODE_ROOT/subprojects/06_dataset_scheduling_experiments/production/verify_code_bundle.py" --root "$H2G_CODE_ROOT" --receipt "$H2G_CODE_RECEIPT" --kind scientific
 subproject="$H2G_CODE_ROOT/subprojects/08_targeted_8b_cpt_experiments"
@@ -28,4 +29,5 @@ env PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3.11 "$subproject/scripts/freeze_cr
   --realized-ledger-receipt "$H2G_STAGE_ROOT/receipts/phase1_phase2_realized_documents.json" \
   --8b-checkpoint-permit "$H2G_8B_UPDATE_3218_PERMIT" \
   --1p5b-checkpoint-permit "$H2G_1P5B_UPDATE_3218_PERMIT" \
+  --producer-compatibility "$H2G_PRODUCER_COMPATIBILITY" \
   --output "$out"

--- a/subprojects/08_targeted_8b_cpt_experiments/clariden/freeze_extension_artifact_manifest_debug.sbatch
+++ b/subprojects/08_targeted_8b_cpt_experiments/clariden/freeze_extension_artifact_manifest_debug.sbatch
@@ -34,7 +34,6 @@ case "$H2G_GATE_STAGE:$H2G_MANIFEST_MODE" in
       "main_8b_update_3218_checkpoint_permit=$H2G_8B_UPDATE_3218_PERMIT"
       "main_1p5b_update_3218_checkpoint_permit=$H2G_1P5B_UPDATE_3218_PERMIT"
       "cross_scale_realized_sample_ledger_match_through_3218=$receipts/cross_scale_realized_ledger_match.json"
-      "same_stack_sentinel_calibration_state=$receipts/greekmmlu_sentinel_calibration_authority.json"
       "phase_3_unseen_blend_and_capacity_receipt=$receipts/phase3_authority.json"
       "phase_local_cursor_guard_receipt=$receipts/phase_local_cursor_guard.json"
       "constant_floor_scheduler_resume_receipt=$receipts/constant_floor_scheduler_resume.json"
@@ -50,7 +49,6 @@ case "$H2G_GATE_STAGE:$H2G_MANIFEST_MODE" in
       "main_8b_update_3218_checkpoint_permit=$H2G_8B_UPDATE_3218_PERMIT"
       "main_1p5b_update_3218_checkpoint_permit=$H2G_1P5B_UPDATE_3218_PERMIT"
       "cross_scale_realized_sample_ledger_match_through_3218=$receipts/cross_scale_realized_ledger_match.json"
-      "same_stack_sentinel_calibration_state=$receipts/greekmmlu_sentinel_calibration_authority.json"
       "phase_3_unseen_blend_and_capacity_receipt=$receipts/phase3_authority.json"
       "phase_local_cursor_guard_receipt=$receipts/phase_local_cursor_guard.json"
       "constant_floor_scheduler_resume_receipt=$receipts/constant_floor_scheduler_resume.json"
@@ -68,6 +66,7 @@ case "$H2G_GATE_STAGE:$H2G_MANIFEST_MODE" in
   pre_finalization:final)
     final="$H2G_STAGE_ROOT/evaluation/final_matched_evidence"
     rows=(
+      "same_stack_sentinel_calibration_state=$receipts/greekmmlu_sentinel_calibration_authority.json"
       "all_required_source_panel_receipts=$final/source_panel_authority.json"
       "all_required_greekmmlu_receipts=$final/greekmmlu_authority.json"
       "all_required_native_suite_receipts=$final/native_suite_authority.json"

--- a/subprojects/08_targeted_8b_cpt_experiments/configs/hard_h_to_g_replication_v1.json
+++ b/subprojects/08_targeted_8b_cpt_experiments/configs/hard_h_to_g_replication_v1.json
@@ -637,7 +637,6 @@
       "main_8b_update_3218_checkpoint_permit",
       "main_1p5b_update_3218_checkpoint_permit",
       "cross_scale_realized_sample_ledger_match_through_3218",
-      "same_stack_sentinel_calibration_state",
       "phase_3_unseen_blend_and_capacity_receipt",
       "phase_local_cursor_guard_receipt",
       "constant_floor_scheduler_resume_receipt",
@@ -648,6 +647,7 @@
       "phase_3_3456_to_3457_resume_receipts"
     ],
     "required_pre_finalization_artifacts": [
+      "same_stack_sentinel_calibration_state",
       "all_required_source_panel_receipts",
       "all_required_greekmmlu_receipts",
       "all_required_native_suite_receipts",

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_cross_scale_realized_ledger.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_cross_scale_realized_ledger.py
@@ -10,25 +10,150 @@ from typing import Any
 
 from contract_utils import executing_code_bundle, file_binding, read_json, require, write_json_atomic
 from freeze_phase_blend_cache import validate_receipt as validate_phase_cache
+from producer_bundle_compatibility import load_authority, require_accepted_producer
 
 
 EXPECTED_CACHE_SAMPLES = {1: 2_315_264, 2: 979_968}
 
 
-def validate_cache(path: Path, phase: int) -> dict[str, Any]:
+def validate_cache(
+    path: Path,
+    phase: int,
+    *,
+    accepted_producers: set[tuple[str, str, str, int, str]],
+) -> dict[str, Any]:
     value = read_json(path)
     data_path = Path(str(value.get("data_path_spec", {}).get("path", "")))
     cache_root = Path(str(value.get("cache_root", "")))
-    validate_phase_cache(value, phase=phase, data_path_spec=data_path, cache_root=cache_root)
+    accepted_code_bundles = {
+        (root, tree)
+        for root, tree, _receipt, _bytes, _sha256 in accepted_producers
+    }
+    validate_phase_cache(
+        value,
+        phase=phase,
+        data_path_spec=data_path,
+        cache_root=cache_root,
+        accepted_code_bundles=accepted_code_bundles,
+    )
+    require_accepted_producer(value, accepted_producers, f"Phase-{phase} cache receipt")
     return value
+
+
+def bound_json(binding: dict[str, Any], label: str) -> tuple[Path, dict[str, Any]]:
+    require(isinstance(binding, dict), f"{label} binding missing")
+    path = Path(str(binding.get("path", "")))
+    require(path.is_file() and binding == file_binding(path), f"{label} binding drift")
+    return path, read_json(path)
+
+
+def validate_cache_lineage(
+    path: Path,
+    canonical_path: Path,
+    *,
+    phase: int,
+    accepted_producers: set[tuple[str, str, str, int, str]],
+) -> dict[str, Any]:
+    """Prove a scale-specific cache contains the canonical training cache unchanged.
+
+    The 1.5B runs use qualification-overlay cache roots so validation indices can
+    coexist with the canonical training indices.  The training files are seeded
+    as hardlinks from the canonical cache; requiring receipt identity here would
+    reject that proven superset even though the optimizer sees the same samples.
+    """
+
+    canonical = validate_cache(
+        canonical_path, phase, accepted_producers=accepted_producers
+    )
+    observed = validate_cache(path, phase, accepted_producers=accepted_producers)
+    if file_binding(path) == file_binding(canonical_path):
+        return {
+            "cache_receipt": file_binding(path),
+            "canonical_cache_receipt": file_binding(canonical_path),
+            "lineage_kind": "canonical_identity",
+        }
+
+    if (
+        observed.get("cache_tree_sha256") == canonical.get("cache_tree_sha256")
+        and observed.get("cache_files") == canonical.get("cache_files")
+        and observed.get("data_path_spec") == canonical.get("data_path_spec")
+        and observed.get("data_path_tokens") == canonical.get("data_path_tokens")
+        and Path(str(observed.get("cache_root", ""))).resolve()
+        == Path(str(canonical.get("cache_root", ""))).resolve()
+    ):
+        return {
+            "cache_receipt": file_binding(path),
+            "canonical_cache_receipt": file_binding(canonical_path),
+            "lineage_kind": "canonical_content_identity",
+        }
+
+    build_path, build = bound_json(observed.get("blend_manifest"), "overlay cache-build")
+    require_accepted_producer(build, accepted_producers, "overlay cache-build")
+    require(
+        build.get("schema_version") == "apertus_hard_h_to_g_phase_cache_build_v1"
+        and build.get("status") == "passed"
+        and int(build.get("phase", -1)) == phase
+        and Path(str(build.get("cache_root", ""))).resolve()
+        == Path(str(observed.get("cache_root", ""))).resolve()
+        and build.get("source_cache_receipt") == file_binding(canonical_path),
+        f"Phase-{phase} overlay cache-build lineage drift",
+    )
+    overlay_path, overlay = bound_json(
+        build.get("qualification_overlay_receipt"), "qualification overlay"
+    )
+    require_accepted_producer(overlay, accepted_producers, "qualification overlay")
+    materialization = overlay.get("materialization", {})
+    source_inventory = materialization.get("source_live_inventory_at_adoption", {})
+    require(
+        overlay.get("schema_version") == "apertus_hard_h_to_g_phase_cache_overlay_v1"
+        and int(overlay.get("phase", -1)) == phase
+        and Path(str(overlay.get("overlay_root", ""))).resolve()
+        == Path(str(observed.get("cache_root", ""))).resolve()
+        and materialization.get("source_cache_receipt") == file_binding(canonical_path)
+        and materialization.get("methods")
+        == {"byte_copy": 0, "hardlink": len(canonical.get("cache_files", []))}
+        and source_inventory.get("missing_relative_paths") == []
+        and source_inventory.get("changed_relative_paths") == []
+        and source_inventory.get("added_relative_paths") == []
+        and int(source_inventory.get("observed_file_count", -1))
+        == len(canonical.get("cache_files", []))
+        and source_inventory.get("observed_tree_sha256")
+        == canonical.get("cache_tree_sha256"),
+        f"Phase-{phase} qualification-overlay provenance drift",
+    )
+    canonical_files = {
+        row["relative_path"]: (int(row["bytes"]), str(row["sha256"]))
+        for row in canonical.get("cache_files", [])
+    }
+    observed_files = {
+        row["relative_path"]: (int(row["bytes"]), str(row["sha256"]))
+        for row in observed.get("cache_files", [])
+    }
+    seed_files = {
+        row["relative_path"]: (int(row["bytes"]), str(row["sha256"]))
+        for row in overlay.get("seed_files", [])
+    }
+    require(
+        canonical_files and seed_files == canonical_files
+        and all(observed_files.get(name) == identity for name, identity in canonical_files.items()),
+        f"Phase-{phase} canonical training-cache files are not an exact overlay subset",
+    )
+    return {
+        "cache_receipt": file_binding(path),
+        "canonical_cache_receipt": file_binding(canonical_path),
+        "lineage_kind": "hardlinked_canonical_superset",
+        "cache_build_receipt": file_binding(build_path),
+        "qualification_overlay_receipt": file_binding(overlay_path),
+    }
 
 
 def validate_endpoint_permit(
     path: Path,
     *,
     scale: str,
-    phase2_binding: dict[str, Any],
-    current_bundle: dict[str, Any],
+    canonical_phase1_path: Path,
+    canonical_phase2_path: Path,
+    accepted_producers: set[tuple[str, str, str, int, str]],
 ) -> dict[str, Any]:
     permit = read_json(path)
     require(permit.get("schema_version") == "apertus_hard_h_to_g_checkpoint_permit_v2", f"{scale}: checkpoint permit schema drift")
@@ -39,19 +164,22 @@ def validate_endpoint_permit(
         and permit.get("update") == 3218,
         f"{scale}: endpoint permit identity drift",
     )
-    require(permit.get("source_phase_cache_receipt") == phase2_binding, f"{scale}: Phase-2 cache binding drift")
-    bundle = permit.get("executing_code_bundle")
-    require(
-        isinstance(bundle, dict)
-        and bundle.get("root") == current_bundle["root"]
-        and bundle.get("tree_sha256") == current_bundle["tree_sha256"],
-        f"{scale}: checkpoint permit code-bundle drift",
+    require_accepted_producer(permit, accepted_producers, f"{scale} checkpoint permit")
+    phase2_path, _ = bound_json(
+        permit.get("source_phase_cache_receipt"), f"{scale} Phase-2 cache"
+    )
+    phase2_lineage = validate_cache_lineage(
+        phase2_path,
+        canonical_phase2_path,
+        phase=2,
+        accepted_producers=accepted_producers,
     )
     audit_binding = permit.get("checkpoint_audit")
     require(isinstance(audit_binding, dict), f"{scale}: checkpoint audit binding missing")
     audit_path = Path(str(audit_binding.get("path", "")))
     require(audit_path.is_file() and audit_binding == file_binding(audit_path), f"{scale}: checkpoint audit binding drift")
     audit = read_json(audit_path)
+    require_accepted_producer(audit, accepted_producers, f"{scale} checkpoint audit")
     require(
         audit.get("schema_version") == "apertus_hard_h_to_g_checkpoint_state_audit_v1"
         and audit.get("status") == "passed"
@@ -60,7 +188,10 @@ def validate_endpoint_permit(
         and audit.get("update") == 3218,
         f"{scale}: checkpoint audit identity drift",
     )
-    require(audit.get("source_phase_cache_receipt") == phase2_binding, f"{scale}: audit cache binding drift")
+    require(
+        audit.get("source_phase_cache_receipt") == file_binding(phase2_path),
+        f"{scale}: audit cache binding drift",
+    )
     require(
         audit.get("data_cursor") == {
             "global_consumed_samples": 3_295_232,
@@ -69,7 +200,52 @@ def validate_endpoint_permit(
         },
         f"{scale}: endpoint data cursor drift",
     )
-    return permit
+    preflight_path, preflight = bound_json(
+        audit.get("segment_preflight"), f"{scale} Phase-2 segment preflight"
+    )
+    require_accepted_producer(preflight, accepted_producers, f"{scale} Phase-2 segment preflight")
+    require(
+        preflight.get("schema_version") == "apertus_hard_h_to_g_train_segment_preflight_v1"
+        and preflight.get("status") == "passed"
+        and preflight.get("scale") == scale
+        and preflight.get("phase") == 2
+        and preflight.get("start_update") == 2261
+        and preflight.get("exit_update") == 3218
+        and preflight.get("phase_cache_receipt") == file_binding(phase2_path),
+        f"{scale}: Phase-2 segment preflight drift",
+    )
+    phase1_path, _ = bound_json(
+        preflight.get("source_phase_cache_receipt"), f"{scale} Phase-1 cache"
+    )
+    phase1_lineage = validate_cache_lineage(
+        phase1_path,
+        canonical_phase1_path,
+        phase=1,
+        accepted_producers=accepted_producers,
+    )
+    phase1_permit_path, phase1_permit = bound_json(
+        preflight.get("checkpoint_permit"), f"{scale} update-2261 checkpoint permit"
+    )
+    require_accepted_producer(
+        phase1_permit, accepted_producers, f"{scale} update-2261 checkpoint permit"
+    )
+    require(
+        phase1_permit.get("schema_version") == "apertus_hard_h_to_g_checkpoint_permit_v2"
+        and phase1_permit.get("status") == "passed"
+        and phase1_permit.get("scale") == scale
+        and phase1_permit.get("source_phase") == 1
+        and phase1_permit.get("update") == 2261
+        and phase1_permit.get("source_phase_cache_receipt") == file_binding(phase1_path),
+        f"{scale}: update-2261 checkpoint-permit lineage drift",
+    )
+    return {
+        "endpoint_checkpoint_permit": file_binding(path),
+        "endpoint_checkpoint_audit": file_binding(audit_path),
+        "phase2_segment_preflight": file_binding(preflight_path),
+        "phase1_checkpoint_permit": file_binding(phase1_permit_path),
+        "phase1_cache_lineage": phase1_lineage,
+        "phase2_cache_lineage": phase2_lineage,
+    }
 
 
 def main() -> int:
@@ -79,17 +255,20 @@ def main() -> int:
     parser.add_argument("--realized-ledger-receipt", type=Path, required=True)
     parser.add_argument("--8b-checkpoint-permit", type=Path, required=True)
     parser.add_argument("--1p5b-checkpoint-permit", type=Path, required=True)
+    parser.add_argument("--producer-compatibility", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
     require(not args.output.exists(), f"immutable cross-scale ledger authority exists: {args.output}")
     current_bundle = executing_code_bundle()
-    validate_cache(args.phase1_cache_receipt, 1)
-    validate_cache(args.phase2_cache_receipt, 2)
+    _, accepted_producers = load_authority(args.producer_compatibility, current_bundle)
+    validate_cache(args.phase1_cache_receipt, 1, accepted_producers=accepted_producers)
+    validate_cache(args.phase2_cache_receipt, 2, accepted_producers=accepted_producers)
     cache_bindings = {
         1: file_binding(args.phase1_cache_receipt),
         2: file_binding(args.phase2_cache_receipt),
     }
     ledger = read_json(args.realized_ledger_receipt)
+    require_accepted_producer(ledger, accepted_producers, "realized document ledger")
     require(ledger.get("schema_version") == "apertus_hard_h_to_g_realized_document_ledger_v1", "realized-ledger schema drift")
     require(ledger.get("status") == "passed", "realized-ledger did not pass")
     rows = ledger.get("cache_receipts")
@@ -107,21 +286,18 @@ def main() -> int:
     )
     trajectory_sha = str(ledger.get("realized_sample_trajectory_sha256", ""))
     require(len(trajectory_sha) == 64, "realized sample trajectory SHA-256 missing")
-    ledger_bundle = ledger.get("executing_code_bundle")
-    require(
-        isinstance(ledger_bundle, dict)
-        and ledger_bundle.get("root") == current_bundle["root"]
-        and ledger_bundle.get("tree_sha256") == current_bundle["tree_sha256"],
-        "realized-ledger code-bundle drift",
-    )
-    phase2_binding = cache_bindings[2]
-    validate_endpoint_permit(
+    scale_lineage = {}
+    scale_lineage["8b"] = validate_endpoint_permit(
         args.__dict__["8b_checkpoint_permit"], scale="8b",
-        phase2_binding=phase2_binding, current_bundle=current_bundle,
+        canonical_phase1_path=args.phase1_cache_receipt,
+        canonical_phase2_path=args.phase2_cache_receipt,
+        accepted_producers=accepted_producers,
     )
-    validate_endpoint_permit(
+    scale_lineage["1p5b"] = validate_endpoint_permit(
         args.__dict__["1p5b_checkpoint_permit"], scale="1p5b",
-        phase2_binding=phase2_binding, current_bundle=current_bundle,
+        canonical_phase1_path=args.phase1_cache_receipt,
+        canonical_phase2_path=args.phase2_cache_receipt,
+        accepted_producers=accepted_producers,
     )
     payload = {
         "schema_version": "apertus_hard_h_to_g_cross_scale_ledger_match_v1",
@@ -130,16 +306,18 @@ def main() -> int:
         "executing_code_bundle": current_bundle,
         "phase_cache_receipts": {str(phase): binding for phase, binding in cache_bindings.items()},
         "realized_ledger_receipt": file_binding(args.realized_ledger_receipt),
+        "producer_bundle_compatibility": file_binding(args.producer_compatibility),
         "realized_sample_trajectory_sha256": trajectory_sha,
         "endpoint_checkpoint_permits": {
             "8b": file_binding(args.__dict__["8b_checkpoint_permit"]),
             "1p5b": file_binding(args.__dict__["1p5b_checkpoint_permit"]),
         },
+        "scale_cache_lineage": scale_lineage,
         "matched_through_update": 3218,
         "global_consumed_samples": 3_295_232,
         "phase_2_local_consumed_samples": 979_968,
         "invariants": {
-            "both_scales_bind_the_same_phase_1_and_phase_2_caches": True,
+            "both_scales_bind_canonical_or_proven_hardlink_superset_phase_caches": True,
             "both_scales_bind_the_same_exact_index_derived_trajectory": True,
             "both_checkpoint_audits_restore_the_same_phase_local_cursor": True,
             "quota_inference_used": False,

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_hard_h_to_g_contract.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_hard_h_to_g_contract.py
@@ -103,7 +103,6 @@ PRE_EXTENSION_ARTIFACTS = [
     "main_8b_update_3218_checkpoint_permit",
     "main_1p5b_update_3218_checkpoint_permit",
     "cross_scale_realized_sample_ledger_match_through_3218",
-    "same_stack_sentinel_calibration_state",
     "phase_3_unseen_blend_and_capacity_receipt",
     "phase_local_cursor_guard_receipt",
     "constant_floor_scheduler_resume_receipt",
@@ -114,6 +113,7 @@ PRE_SECOND_EXTENSION_ARTIFACTS = [
     "phase_3_3456_to_3457_resume_receipts",
 ]
 PRE_FINALIZATION_ARTIFACTS = [
+    "same_stack_sentinel_calibration_state",
     "all_required_source_panel_receipts",
     "all_required_greekmmlu_receipts",
     "all_required_native_suite_receipts",

--- a/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_producer_bundle_compatibility.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_producer_bundle_compatibility.py
@@ -205,6 +205,7 @@ ALLOWED_CHANGED_PATHS = frozenset(
         "subprojects/08_targeted_8b_cpt_experiments/scripts/evaluate_td_objective.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_1p5b_td_policy_authorization.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_cross_scale_sentinel_authority.py",
+        "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_cross_scale_realized_ledger.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_production_timing_and_allocation.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_statistical_decision_contract.py",
         "subprojects/08_targeted_8b_cpt_experiments/scripts/freeze_submission_dry_run.py",

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
@@ -1096,6 +1096,19 @@ class HardHToGContractTests(unittest.TestCase):
         self.assertIn("#SBATCH --partition=debug", finalizer)
         self.assertIn("verify_data_runtime.py", finalizer)
 
+    def test_cross_scale_ledger_accepts_only_audited_producer_bundles(self) -> None:
+        producer = (ROOT / "scripts/freeze_cross_scale_realized_ledger.py").read_text(
+            encoding="utf-8"
+        )
+        wrapper = (ROOT / "clariden/freeze_cross_scale_realized_ledger_debug.sbatch").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('parser.add_argument("--producer-compatibility"', producer)
+        self.assertIn("require_accepted_producer(permit", producer)
+        self.assertIn("require_accepted_producer(audit", producer)
+        self.assertIn("require_accepted_producer(ledger", producer)
+        self.assertIn("H2G_PRODUCER_COMPATIBILITY", wrapper)
+
     def test_production_timing_requires_measured_wall_and_test_only_evidence(self) -> None:
         finalizer = (ROOT / "scripts/freeze_production_timing_and_allocation.py").read_text(encoding="utf-8")
         wrapper = (ROOT / "clariden/freeze_production_timing_and_allocation_debug.sbatch").read_text(encoding="utf-8")

--- a/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
+++ b/subprojects/08_targeted_8b_cpt_experiments/tests/test_hard_h_to_g_contracts.py
@@ -126,6 +126,8 @@ class HardHToGContractTests(unittest.TestCase):
             "pre_finalization": PRE_FINALIZATION_ARTIFACTS,
         })
         self.assertNotIn("phase_3_unseen_blend_and_capacity_receipt", PRE_MAIN_ARTIFACTS)
+        self.assertNotIn("same_stack_sentinel_calibration_state", PRE_EXTENSION_ARTIFACTS)
+        self.assertIn("same_stack_sentinel_calibration_state", PRE_FINALIZATION_ARTIFACTS)
         for scale in ("8b", "1p5b"):
             self.assertEqual(
                 artifacts_for_stage("pre_main", scale),
@@ -1264,6 +1266,7 @@ class HardHToGContractTests(unittest.TestCase):
 
     def test_sentinel_freeze_is_transactional_and_cross_scale_authorized(self) -> None:
         freeze = (ROOT / "clariden/freeze_greekmmlu_sentinels_debug.sbatch").read_text(encoding="utf-8")
+        extension_manifest = (ROOT / "clariden/freeze_extension_artifact_manifest_debug.sbatch").read_text(encoding="utf-8")
         authority = (ROOT / "scripts/freeze_cross_scale_sentinel_authority.py").read_text(encoding="utf-8")
         self.assertIn(".greekmmlu_sentinels.${SLURM_JOB_ID}.partial", freeze)
         self.assertIn('mv "$temporary" "$root"', freeze)
@@ -1275,6 +1278,11 @@ class HardHToGContractTests(unittest.TestCase):
             ROLE_SCHEMAS["same_stack_sentinel_calibration_state"],
             "apertus_greekmmlu_sentinel_calibration_authority_v1",
         )
+        pre_extension, pre_finalization = extension_manifest.split(
+            "pre_finalization:final)", maxsplit=1
+        )
+        self.assertNotIn("same_stack_sentinel_calibration_state", pre_extension)
+        self.assertIn("same_stack_sentinel_calibration_state", pre_finalization)
 
     def test_replay_filters_precede_stage_b_and_post_audits_bind_stage_b_bytes(self) -> None:
         stage_b = (ROOT / "clariden/anonymize_training_stream_debug.sbatch").read_text(encoding="utf-8")


### PR DESCRIPTION
GreekMMLU sentinel calibration is evaluation-only and consumes saved checkpoints. It does not change the Phase-3 dataset, sample cursor, optimizer, scheduler, or model state.

This moves same_stack_sentinel_calibration_state from pre_extension to pre_finalization, allowing calibration to run concurrently with Phase 3 while remaining mandatory for the final evidence package.

Training-critical pre-extension checks remain unchanged: both update-3218 permits, realized-ledger equality, unseen Phase-3 capacity/cache authority, phase-local cursor, constant-floor scheduler continuation, and owner authorization.

Validation:
- focused contract and sentinel-gate tests pass
- configuration JSON parses
- wrapper shell syntax passes
- Python syntax and git diff checks pass

The unrelated pre-existing failures in the broader branch test file are unchanged.